### PR TITLE
PH-2828 refactor: 일간 뷰 수정

### DIFF
--- a/src/WeekView/WeekView.js
+++ b/src/WeekView/WeekView.js
@@ -399,7 +399,7 @@ export default class WeekView extends Component {
       onDragEvent,
       isRefreshing,
       RefreshComponent,
-      getTargetDate,
+      onGetTargetDate,
     } = this.props;
     const { currentMoment, initialDates } = this.state;
     const times = this.calculateTimes(timeStep, formatTimeLabel);
@@ -408,7 +408,7 @@ export default class WeekView extends Component {
       (prependMostRecent && !rightToLeft) ||
       (!prependMostRecent && rightToLeft);
 
-    getTargetDate(this.getTargetDate());
+    onGetTargetDate(this.getTargetDate());
 
     return (
       <View style={styles.container}>
@@ -560,7 +560,7 @@ WeekView.propTypes = {
   onDragEvent: PropTypes.func,
   isRefreshing: PropTypes.bool,
   RefreshComponent: PropTypes.elementType,
-  getTargetDate: PropTypes.func,
+  onGetTargetDate: PropTypes.func,
 };
 
 WeekView.defaultProps = {
@@ -575,4 +575,5 @@ WeekView.defaultProps = {
   rightToLeft: false,
   prependMostRecent: false,
   RefreshComponent: ActivityIndicator,
+  onGetTargetDate: () => {},
 };

--- a/src/WeekView/WeekView.js
+++ b/src/WeekView/WeekView.js
@@ -71,6 +71,7 @@ export default class WeekView extends Component {
       const initialDates = this.calculatePagesDates(
         this.state.currentMoment,
         this.props.numberOfDays,
+        this.props.weekStartsOn,
         this.props.prependMostRecent,
         this.props.fixedHorizontally,
       );


### PR DESCRIPTION
### Summary

캘린더 일 수를 계산하는 로직에서 잘못된 부분 수정

### Story

캘린더 주간과 일간 뷰를 볼 수 있습니다

### Changes

- 일 수 계산하는 로직에서 인자 빠진 부분 수정
- props로 받는 함수명 prefix 수정


### Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionally)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Test
- [ ] Documentation
- [X] Refactoring


### Screenshots or Videos


### How to test (Optional)
*How to test this PR*