### PR TITLE
PH-3265 refactor: 캘린더 사이즈 아이폰 노치 대응

### DIFF
--- a/src/Events/Events.js
+++ b/src/Events/Events.js
@@ -82,10 +82,7 @@ const addOverlappedToArray = (baseArr, overlappedArr, itemWidth) => {
           overlappedArr[lastEvtInLaneIndex];
         if (
           !lastEvtInLane ||
-          !areEventsOverlapped(
-            lastEvtInLane.data.endDate,
-            event.data.startDate,
-          )
+          !areEventsOverlapped(lastEvtInLane.data.endDate, event.data.startDate)
         ) {
           // Place in this lane
           latestByLane[lane] = index;
@@ -115,7 +112,11 @@ const addOverlappedToArray = (baseArr, overlappedArr, itemWidth) => {
   });
 };
 
-const getEventsWithPosition = (totalEvents, regularItemWidth, hoursInDisplay) => {
+const getEventsWithPosition = (
+  totalEvents,
+  regularItemWidth,
+  hoursInDisplay,
+) => {
   return totalEvents.map((events) => {
     let overlappedSoFar = []; // Store events overlapped until now
     let lastDate = null;
@@ -131,21 +132,13 @@ const getEventsWithPosition = (totalEvents, regularItemWidth, hoursInDisplay) =>
         const endDate = moment(event.endDate);
         lastDate = lastDate ? moment.max(endDate, lastDate) : endDate;
       } else {
-        addOverlappedToArray(
-          eventsAcc,
-          overlappedSoFar,
-          regularItemWidth,
-        );
+        addOverlappedToArray(eventsAcc, overlappedSoFar, regularItemWidth);
         overlappedSoFar = [eventWithStyle];
         lastDate = moment(event.endDate);
       }
       return eventsAcc;
     }, []);
-    addOverlappedToArray(
-      eventsWithStyle,
-      overlappedSoFar,
-      regularItemWidth,
-    );
+    addOverlappedToArray(eventsWithStyle, overlappedSoFar, regularItemWidth);
     return eventsWithStyle;
   });
 };
@@ -158,9 +151,9 @@ class Events extends PureComponent {
   };
 
   getEventItemWidth = (padded = true) => {
-    const { numberOfDays } = this.props;
+    const { numberOfDays, insets } = this.props;
     const fullWidth = padded ? EVENTS_CONTAINER_WIDTH : CONTAINER_WIDTH;
-    return fullWidth / numberOfDays;
+    return (fullWidth - insets?.left - insets?.right) / numberOfDays;
   };
 
   processEvents = memoizeOne(
@@ -245,6 +238,7 @@ class Events extends PureComponent {
       showNowLine,
       nowLineColor,
       onDragEvent,
+      insets,
     } = this.props;
     const totalEvents = this.processEvents(
       eventsByDate,
@@ -254,8 +248,13 @@ class Events extends PureComponent {
       rightToLeft,
     );
 
+    const containerStyle = {
+      ...styles.container,
+      width: CONTAINER_WIDTH - insets?.left - insets?.right,
+    };
+
     return (
-      <View style={styles.container}>
+      <View style={containerStyle}>
         {times.map((time) => (
           <View
             key={time}
@@ -321,6 +320,7 @@ Events.propTypes = {
   showNowLine: PropTypes.bool,
   nowLineColor: PropTypes.string,
   onDragEvent: PropTypes.func,
+  insets: PropTypes.object.isRequired,
 };
 
 export default Events;

--- a/src/WeekView/WeekView.js
+++ b/src/WeekView/WeekView.js
@@ -360,11 +360,14 @@ export default class WeekView extends Component {
     return sortedEvents;
   });
 
-  getListItemLayout = (index) => ({
-    length: CONTAINER_WIDTH,
-    offset: CONTAINER_WIDTH * index,
-    index,
-  });
+  getListItemLayout = (index) => {
+    const { insets } = this.props;
+    return {
+      length: CONTAINER_WIDTH - insets?.left - insets?.right,
+      offset: (CONTAINER_WIDTH - insets?.left - insets?.right) * index,
+      index,
+    };
+  };
 
   getTargetDate = () => {
     const { currentMoment } = this.state;
@@ -400,6 +403,7 @@ export default class WeekView extends Component {
       isRefreshing,
       RefreshComponent,
       onGetTargetDate,
+      insets,
     } = this.props;
     const { currentMoment, initialDates } = this.state;
     const times = this.calculateTimes(timeStep, formatTimeLabel);
@@ -407,6 +411,14 @@ export default class WeekView extends Component {
     const horizontalInverted =
       (prependMostRecent && !rightToLeft) ||
       (!prependMostRecent && rightToLeft);
+    const calendarHeaderStyle = {
+      ...styles.header,
+      width: CONTAINER_WIDTH - insets?.left - insets?.right,
+    };
+    const loadingSpinnerStyle = {
+      ...styles.loadingSpinner,
+      right: (CONTAINER_WIDTH - insets?.left - insets?.right) / 2,
+    };
 
     onGetTargetDate(this.getTargetDate());
 
@@ -435,7 +447,7 @@ export default class WeekView extends Component {
             initialScrollIndex={this.pageOffset}
             renderItem={({ item }) => {
               return (
-                <View key={item} style={styles.header}>
+                <View key={item} style={calendarHeaderStyle}>
                   <Header
                     style={headerStyle}
                     textStyle={headerTextStyle}
@@ -452,7 +464,7 @@ export default class WeekView extends Component {
           />
         </View>
         {isRefreshing && RefreshComponent && (
-          <RefreshComponent style={styles.loadingSpinner} />
+          <RefreshComponent style={loadingSpinnerStyle} />
         )}
         <ScrollView
           onStartShouldSetResponderCapture={() => false}
@@ -497,6 +509,7 @@ export default class WeekView extends Component {
                     showNowLine={showNowLine}
                     nowLineColor={nowLineColor}
                     onDragEvent={onDragEvent}
+                    insets={insets}
                   />
                 );
               }}
@@ -561,6 +574,14 @@ WeekView.propTypes = {
   isRefreshing: PropTypes.bool,
   RefreshComponent: PropTypes.elementType,
   onGetTargetDate: PropTypes.func,
+  insets: PropTypes.arrayOf(
+    PropTypes.shape({
+      top: PropTypes.number,
+      bottom: PropTypes.number,
+      left: PropTypes.number,
+      right: PropTypes.number,
+    }),
+  ),
 };
 
 WeekView.defaultProps = {
@@ -576,4 +597,5 @@ WeekView.defaultProps = {
   prependMostRecent: false,
   RefreshComponent: ActivityIndicator,
   onGetTargetDate: () => {},
+  insets: { top: 0, bottom: 0, left: 0, right: 0 },
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,7 +4,7 @@ import 'moment/locale/ko';
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 export const CONTENT_OFFSET = 16;
-export const CONTAINER_HEIGHT = SCREEN_HEIGHT - 60;
+export const CONTAINER_HEIGHT = SCREEN_HEIGHT > 540 ? SCREEN_HEIGHT : 540;
 export const CONTAINER_WIDTH = SCREEN_WIDTH - 60;
 export const DATE_STR_FORMAT = 'YYYY-MM-DD';
 export const availableNumberOfDays = [1, 3, 5, 7];


### PR DESCRIPTION
### Summary

#### !! fork 받은 라이브러리 수정입니다!
- 캘린더 사이즈 아이폰 노치 대응

### Story

- 캘린더 사이즈 아이폰 노치 대응

### Changes

- `insets` 받아오도록 `props` 추가
- `CONTAINER_WIDTH` 에 `insets.left` `insets.right` 빼도록 처리
- `CONTAINER_HEIGHT` 최소 높이 지정

### Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionally)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Test
- [ ] Documentation
- [X] Refactoring


### Screenshots or Videos



### How to test (Optional)
*How to test this PR*