### PR TITLE
PH-3385 (feat): npm 패키지 배포 셋팅 및 Github Action 셋팅

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: release
+on:
+  push:
+    tags: ["v*"]
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - uses: actions/cache@master
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - run: |
+          yarn install
+          npm publish
+        env:
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@payhereinc:registry=https://npm.pkg.github.com/
+//npm.pkg.github.com/:_authToken=${NPM_TOKEN}

--- a/package.json
+++ b/package.json
@@ -1,17 +1,13 @@
 {
-  "name": "react-native-week-view",
+  "name": "@payhereinc/react-native-week-view",
   "version": "0.6.1",
   "description": "Week View Calendar for React Native",
   "main": "index.js",
-  "author": "Hoang Nguyen (https://github.com/hoangnm)",
-  "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hoangnm/react-native-week-view.git"
+    "url": "https://github.com/payhereinc/react-native-week-view.git"
   },
-  "bugs": {
-    "url": "https://github.com/hoangnm/react-native-week-view/issues"
-  },
+  "author": "mandarinduk <kyudeokbae@payhere.in>",
   "keywords": [
     "android",
     "ios",
@@ -58,5 +54,8 @@
     "setupFilesAfterEnv": [
       "jest-extended"
     ]
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
   }
 }


### PR DESCRIPTION
### Summary

* npm 패키지로 배포가 가능하도록 설정합니다.

### Story

- RN 모듈에 대해 npm 패키지 배포 셋팅

### Changes

* 사내 Github Packages npm 레지스트리 (@payhereinc)에 배포하도록 셋팅합니다.

### Types of changes

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionally)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Test
- [ ] Documentation
- [] Refactoring


### Screenshots or Videos


### How to test (Optional)
*How to test this PR*