### PR TITLE
refactor: 오늘 날짜가 포함된 캘린더에서 현재 시간으로 스크롤 되도록 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payhereinc/react-native-week-view",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Week View Calendar for React Native",
   "main": "index.js",
   "repository": {

--- a/src/WeekView/WeekView.js
+++ b/src/WeekView/WeekView.js
@@ -19,12 +19,13 @@ import Title from '../Title/Title';
 import Times from '../Times/Times';
 import styles from './WeekView.styles';
 import {
-  CONTAINER_HEIGHT,
   DATE_STR_FORMAT,
   availableNumberOfDays,
   setLocale,
   CONTAINER_WIDTH,
   getFormattedDate,
+  CONTENT_OFFSET,
+  minutesToYDimension,
 } from '../utils';
 
 const MINUTES_IN_DAY = 60 * 24;
@@ -91,6 +92,19 @@ export default class WeekView extends Component {
         },
       );
     }
+    if (
+      moment().isSame(this.props.selectedDate, 'date') ||
+      moment().isBetween(
+        this.props.selectedDate,
+        moment(this.props.selectedDate).add(this.props.numberOfDays, 'days'),
+        undefined,
+        '[)',
+      )
+    ) {
+      requestAnimationFrame(() => {
+        this.scrollToVerticalStart();
+      });
+    }
   }
 
   componentWillUnmount() {
@@ -109,8 +123,11 @@ export default class WeekView extends Component {
 
   scrollToVerticalStart = () => {
     if (this.verticalAgenda) {
-      const { startHour, hoursInDisplay } = this.props;
-      const startHeight = (startHour * CONTAINER_HEIGHT) / hoursInDisplay;
+      const { hoursInDisplay } = this.props;
+      const now = new Date();
+      const minutes = now.getHours() * 60 + now.getMinutes();
+      const startHeight =
+        minutesToYDimension(hoursInDisplay, minutes) + CONTENT_OFFSET;
       this.verticalAgenda.scrollTo({ y: startHeight, x: 0, animated: false });
     }
   };


### PR DESCRIPTION
오늘 날짜가 포함된 주간, 또는 오늘 일간 캘린더의 경우 현재 시간으로 캘린더가 스크롤 되도록 수정합니다