### PR TITLE
fix: 캘린더 뷰 변경시마다 일자 계산하던 로직 삭제

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payhereinc/react-native-week-view",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Week View Calendar for React Native",
   "main": "index.js",
   "repository": {

--- a/src/WeekView/WeekView.js
+++ b/src/WeekView/WeekView.js
@@ -72,18 +72,7 @@ export default class WeekView extends Component {
       setLocale(this.props.locale);
     }
     if (this.props.numberOfDays !== prevProps.numberOfDays) {
-      const prevMonth =
-        prevProps.numberOfDays === 7
-          ? moment(this.state.currentMoment).endOf('week').month()
-          : moment(this.state.currentMoment).month();
-      const currentMoment =
-        moment().month() !== prevMonth
-          ? moment(this.state.currentMoment)
-              .endOf('week')
-              .startOf('month')
-              .toDate()
-          : moment().toDate();
-
+      const currentMoment = moment(this.props.selectedDate);
       const initialDates = this.calculatePagesDates(
         currentMoment,
         this.props.numberOfDays,
@@ -220,7 +209,7 @@ export default class WeekView extends Component {
     };
 
     const newState = {};
-    let newStateCallback = () => {};
+    let newStateCallback = () => { };
     // The final target may change, if pages are added
     let targetIndex = target;
 
@@ -281,7 +270,7 @@ export default class WeekView extends Component {
       const newState = {
         currentMoment: newMoment,
       };
-      let newStateCallback = () => {};
+      let newStateCallback = () => { };
 
       if (movedPages < 0 && newPage < this.pageOffset) {
         this.prependPagesInPlace(initialDates, 1);
@@ -635,8 +624,8 @@ WeekView.defaultProps = {
   rightToLeft: false,
   prependMostRecent: false,
   RefreshComponent: ActivityIndicator,
-  onGetTargetDate: () => {},
-  onRefresh: () => {},
+  onGetTargetDate: () => { },
+  onRefresh: () => { },
   isRefreshing: false,
   insets: { top: 0, bottom: 0, left: 0, right: 0 },
 };


### PR DESCRIPTION
### Summary

캘린더 뷰 변경시마다 일자 계산하던 로직 삭제

### Story

캘린더 뷰 변경시마다 일자 계산하던 로직 삭제

### Changes

캘린더 뷰 변경시마다 일자 계산하던 로직 삭제
rn에서 계산해서 넘겨준 값 그대로 처리하도록 수정


### Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionally)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Test
- [ ] Documentation
- [ ] Refactoring


### Screenshots or Videos


### How to test (Optional)
*How to test this PR*